### PR TITLE
Add Makhno to table example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ var table = new MDTableBuilder()
   .WithHeaders("First Name", "Last Name")
   .AddRow("Mark", "Kraus")
   .AddRow("Karl", "Marx")
-  .AddRow("Friedrich", "Engels");
+  .AddRow("Friedrich", "Engels")
+  .AddRow("Nestor", "Makhno");
 Console.WriteLine(table);
 ```
 
@@ -81,6 +82,7 @@ Result:
 | Mark       | Kraus     |
 | Karl       | Marx      |
 | Friedrich  | Engels    |
+| Nestor     | Makhno    |
 ```
 
 When rendered:
@@ -90,3 +92,4 @@ When rendered:
 | Mark       | Kraus     |
 | Karl       | Marx      |
 | Friedrich  | Engels    |
+| Nestor     | Makhno    |


### PR DESCRIPTION
Prior to this change, the example table included Marx and Engels. This change adds the anarchist Makhno to the table to ensure some representation for the Black, as well as the Red.