### PR TITLE
Move Rows to ImmutableArray

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 [assembly: AssemblyTitle("MarkdownUtilities")]
 [assembly: AssemblyDescription("A collection of Markdown Utilities.")]
 [assembly: AssemblyConfiguration("")]

--- a/src/MDTableColumn.cs
+++ b/src/MDTableColumn.cs
@@ -5,21 +5,21 @@ namespace MarkdownUtilities;
 public class MDTableColumn
 {
     public readonly string Header;
-    public ImmutableList<string> Rows { get; private set; }
+    public ImmutableArray<string> Rows => ImmutableArray.Create<string>(_rows.ToArray());
     public int MaxWidth { get; private set; }
-    public int RowCount => Rows is null ? 0 : Rows.Count;
+    public int RowCount => _rows is null ? 0 : _rows.Count;
+    private List<string> _rows = new();
 
     public MDTableColumn(string Header)
     {
         this.Header = string.IsNullOrWhiteSpace(Header) ? " " : Header;
         this.MaxWidth = this.Header.Length;
-        Rows = ImmutableList.Create<string>();
     }
 
     public void AddRow(string row)
     {
         var escaped = EscapeText(row);
-        Rows = Rows.Add(escaped);
+        _rows.Add(escaped);
         UpdateMaxWidth(escaped);
     }
 


### PR DESCRIPTION
ImmutableList<t> has garbage performance. The main goal is to prevent consumers from tampering with the lists outside of the methods. I already knew `.Add()` was expensive, but it turns out iterating over `ImmutableList<t>` is slow. Moved to using an internal `List<string>` and supplying an `ImmutableArray<string>` on demand when the property is accessed.