### PR TITLE
3.0.0 Refactor

### DIFF
--- a/Examples/CsharpTableBuilder/Program.cs
+++ b/Examples/CsharpTableBuilder/Program.cs
@@ -1,6 +1,6 @@
 ﻿using MarkdownUtilities;
 
-var table = new MDTableBuilder()
+var table = new TableBuilder()
   .WithHeaders("First Name", "Last Name")
   .AddRow("Mark", "Kraus")
   .AddRow("Karl", "Marx")

--- a/MarkdownUtilities.slnx
+++ b/MarkdownUtilities.slnx
@@ -1,5 +1,15 @@
 <Solution>
+  <Configurations>
+    <BuildType Name="net6" />
+    <BuildType Name="net21" />
+  </Configurations>
   <Folder Name="/src/">
-    <Project Path="src/MarkdownUtilities.csproj" />
+    <Project Path="src/MarkdownUtilities.csproj">
+      <BuildType Solution="net6|*" Project="net6" />
+      <BuildType Solution="net21|*" Project="net21" />
+    </Project>
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then you can use it un your code like so:
 ```csharp
 using MarkdownUtilities;
 
-var table = new MDTableBuilder()
+var table = new TableBuilder()
   .WithHeaders("A", "B", "C")
   .AddRow("1", "2", "3")
   .AddRow("4", "5", "6")
@@ -50,7 +50,7 @@ Download and extract the the last net21 release.
 
 ```powershell
 Add-Type -Path .\path\to\MarkdownUtilities.dll
-$builder = [MarkdownUtilities.MDTableBuilder]::New()
+$builder = [MarkdownUtilities.TableBuilder]::New()
 $builder.WithHeaders("A", "B", "C").
     AddRow("1", "2", "3").
     AddRow("4", "5", "6").
@@ -65,7 +65,7 @@ $builder.WithHeaders("A", "B", "C").
 The table builder will build a markdown representation of data. It will automatically escape characters that may break the table. It also auto-sizes the columns so that they appear uniform in raw text.
 
 ```csharp
-var table = new MDTableBuilder()
+var table = new TableBuilder()
   .WithHeaders("First Name", "Last Name")
   .AddRow("Mark", "Kraus")
   .AddRow("Karl", "Marx")

--- a/build.ps1
+++ b/build.ps1
@@ -2,19 +2,18 @@ if (!(get-command ILRepack.exe)) {
     dotnet tool install -g dotnet-ilrepack
 }
 
-Push-Location src
-
 # NetStandard 2.1
-dotnet build -c net21
-$Path = "..\Release\MarkdownUtilities.net21\"
-ILRepack.exe /target:library /lib:$Path /internalize /out:$Path/MarkdownUtilities.dll $Path/MarkdownUtilities.dll
-Remove-Item $path/MarkdownUtilities.deps.json
+dotnet build .\MarkdownUtilities.slnx -c net21
+$Path = ".\Release\MarkdownUtilities.net21\"
+$Name = "MarkdownUtilities.net21.dll"
+ILRepack.exe /target:library /lib:$Path /internalize /out:$Path/$Name $Path/$Name
+Remove-Item $path/*.deps.json
 
 # MelonLoader Il2Cpp
-dotnet build -c ML_Cpp_CoreCLR
-$Path = "..\Release\MarkdownUtilities.MelonLoader.IL2CPP.CoreCLR"
-ILRepack.exe /target:library /lib:$Path /internalize /out:$Path/MarkdownUtilities.ML.IL2CPP.CoreCLR.dll $Path/MarkdownUtilities.ML.IL2CPP.CoreCLR.dll
-Remove-Item $path/MarkdownUtilities.ML.IL2CPP.CoreCLR.deps.json
+dotnet build .\MarkdownUtilities.slnx -c net6
+$Path = ".\Release\MarkdownUtilities.net6"
+$Name = "MarkdownUtilities.net6.dll"
+ILRepack.exe /target:library /lib:$Path /internalize /out:$Path/$Name $Path/$Name
+Remove-Item $path/*.deps.json
 
 Get-Date
-Pop-Location

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 [assembly: AssemblyTitle("MarkdownUtilities")]
 [assembly: AssemblyDescription("A collection of Markdown Utilities.")]
 [assembly: AssemblyConfiguration("")]

--- a/src/MarkdownUtilities.csproj
+++ b/src/MarkdownUtilities.csproj
@@ -8,19 +8,19 @@
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Configurations>ML_Cpp_CoreCLR;net21</Configurations>
+    <Configurations>net6;net21</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='ML_Cpp_CoreCLR'">
+  <PropertyGroup Condition="'$(Configuration)'=='net6'">
     <TargetFramework>net6</TargetFramework>
-    <OutputPath>..\Release\MarkdownUtilities.MelonLoader.IL2CPP.CoreCLR\</OutputPath>
-    <AssemblyName>MarkdownUtilities.ML.IL2CPP.CoreCLR</AssemblyName>
+    <OutputPath>..\Release\MarkdownUtilities.net6\</OutputPath>
+    <AssemblyName>MarkdownUtilities.net6</AssemblyName>
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='net21'">
     <OutputPath>..\Release\MarkdownUtilities.net21\</OutputPath>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyName>MarkdownUtilities</AssemblyName>
+    <AssemblyName>MarkdownUtilities.net21</AssemblyName>
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/StringBuilderExtensions.cs
+++ b/src/StringBuilderExtensions.cs
@@ -4,8 +4,9 @@ namespace MarkdownUtilities;
 
 internal static class StringBuilderExtensions
 {
-    public static StringBuilder AppendHeaderRow(this StringBuilder sb, MDTableBuilder TB) => sb.AppendHeaderRow(TB.Columns);
-    public static StringBuilder AppendHeaderRow(this StringBuilder sb, IEnumerable<MDTableColumn> Columns)
+    public static TableBuilder NewTable(this StringBuilder sb) => new(sb);
+    public static StringBuilder AppendHeaderRow(this StringBuilder sb, TableBuilder TB) => sb.AppendHeaderRow(TB.Columns);
+    public static StringBuilder AppendHeaderRow(this StringBuilder sb, IEnumerable<TableColumn> Columns)
     {
         sb.Append('|');
         foreach (var column in Columns)
@@ -18,9 +19,9 @@ internal static class StringBuilderExtensions
         return sb;
     }
 
-    public static StringBuilder AppendSeparatorRow(this StringBuilder sb, MDTableBuilder TB, char SeparatorChar = '-') =>
+    public static StringBuilder AppendSeparatorRow(this StringBuilder sb, TableBuilder TB, char SeparatorChar = '-') =>
         sb.AppendSeparatorRow(TB.Columns, SeparatorChar);
-    public static StringBuilder AppendSeparatorRow(this StringBuilder sb, IEnumerable<MDTableColumn> Columns, char SeparatorChar = '-')
+    public static StringBuilder AppendSeparatorRow(this StringBuilder sb, IEnumerable<TableColumn> Columns, char SeparatorChar = '-')
     {
         sb.Append('|');
         foreach (var column in Columns)
@@ -33,7 +34,7 @@ internal static class StringBuilderExtensions
         return sb;
     }
 
-    public static StringBuilder AppendRows(this StringBuilder sb, MDTableBuilder TB)
+    public static StringBuilder AppendRows(this StringBuilder sb, TableBuilder TB)
     {
         for (int i = 0; i < TB.RowCount; i++)
         {

--- a/src/TableBuilder.cs
+++ b/src/TableBuilder.cs
@@ -2,24 +2,26 @@
 using System.Text;
 
 namespace MarkdownUtilities;
-public class MDTableBuilder
+public class TableBuilder
 {
-    public ImmutableArray<MDTableColumn> Columns { get; private set; }
+    public ImmutableArray<TableColumn> Columns { get; private set; }
     public int RowCount { get; private set; }
     public int ColumnCount { get; private set; }
-    public MDTableBuilder() { }
+    private readonly StringBuilder sb;
+    public TableBuilder() => sb = new();
+    public TableBuilder(StringBuilder sb) => this.sb = sb;
 
-    public MDTableBuilder WithHeaders(params string[] Headers)
+    public TableBuilder WithHeaders(params string[] Headers)
     {
 
-        var columns = Array.ConvertAll(Headers, h => new MDTableColumn(h));
+        var columns = Array.ConvertAll(Headers, h => new TableColumn(h));
         Columns = ImmutableArray.Create(columns);
         RowCount = 0;
         ColumnCount = Columns.Length;
         return this;
     }
 
-    public MDTableBuilder AddRow(params string[] row)
+    public TableBuilder AddRow(params string[] row)
     {
         if (row.Length != ColumnCount)
             throw new ArgumentOutOfRangeException(nameof(row), row, $"Supplied row item count does not match the number of columns. Expected {ColumnCount} row items.");
@@ -29,14 +31,16 @@ public class MDTableBuilder
         return this;
     }
 
-    public string Build() => ToString();
-
-    public override string ToString()
-    {
-        var sb = new StringBuilder()
+    public StringBuilder Build() =>
+        sb
             .AppendHeaderRow(this)
             .AppendSeparatorRow(this)
             .AppendRows(this);
-        return sb.ToString();
-    }    
+
+    public override string ToString() =>
+         sb
+            .AppendHeaderRow(this)
+            .AppendSeparatorRow(this)
+            .AppendRows(this)
+            .ToString();
 }

--- a/src/TableBuilderExtensions.cs
+++ b/src/TableBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+namespace MarkdownUtilities;
+
+public static class TableBuilderExtensions
+{
+    public static TableBuilder NewTable(this StringBuilder sb) => new(sb);
+    public static TableBuilder ForEachAddRow<T>(this TableBuilder tb, IEnumerable<T> enumerator, Func<T, IEnumerable<string>> forEach)
+    {
+        foreach (var item in enumerator)
+        {
+            tb.AddRow(forEach(item).ToArray());
+        }
+        return tb;
+    }
+
+    public static TableBuilder WithPropertyValueHeaders(this TableBuilder tb) => tb.WithHeaders("Property", "Value");
+    public static TableBuilder WithNameValueHeaders(this TableBuilder tb) => tb.WithHeaders("Name", "Value");
+    public static TableBuilder AddRowIfNotNull<T>(this TableBuilder tb, T nullCheckObject, Func<T, IEnumerable<string>> notNullAction) =>
+        nullCheckObject is null
+        ? tb
+        : tb.AddRow(notNullAction(nullCheckObject).ToArray());
+}

--- a/src/TableColumn.cs
+++ b/src/TableColumn.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 
 namespace MarkdownUtilities;
 
-public class MDTableColumn
+public class TableColumn
 {
     public readonly string Header;
     public ImmutableArray<string> Rows => ImmutableArray.Create<string>(_rows.ToArray());
@@ -10,9 +10,9 @@ public class MDTableColumn
     public int RowCount => _rows is null ? 0 : _rows.Count;
     private List<string> _rows = new();
 
-    public MDTableColumn(string Header)
+    public TableColumn(string Header)
     {
-        this.Header = string.IsNullOrWhiteSpace(Header) ? " " : Header;
+        this.Header = string.IsNullOrWhiteSpace(Header) ? " " : EscapeText(Header);
         this.MaxWidth = this.Header.Length;
     }
 

--- a/tests/TableBuilderTests.cs
+++ b/tests/TableBuilderTests.cs
@@ -1,0 +1,48 @@
+using MarkdownUtilities;
+
+namespace tests;
+
+public class TableBuilderTests
+{
+    public const string resultTable = """
+    | a        | b           | c         |
+    | -------- | ----------- | --------- |
+    | 11111111 | 2           | 3         |
+    | 4        | 55555555555 | 6         |
+    | 7        | 8           | 999999999 |
+
+    """;
+
+    public const string resultEscapedTable = """
+    | Escaped\| |
+    | --------- |
+    | \|        |
+    | \\        |
+    
+    """;
+
+    [Fact]
+    public void TableBuilderNormalTable()
+    {
+        var tb = new TableBuilder();
+        var testResult = tb
+            .WithHeaders("a", "b", "c")
+            .AddRow("11111111", "2", "3")
+            .AddRow("4", "55555555555", "6")
+            .AddRow("7", "8", "999999999")
+            .ToString();
+        Assert.Equal(resultTable, testResult);
+    }
+
+    [Fact]
+    public void TableBuilderEscapedData()
+    {
+        var tb = new TableBuilder();
+        var testResult = tb
+            .WithHeaders("Escaped|")
+            .AddRow("|")
+            .AddRow("\\")
+            .ToString();
+        Assert.Equal(resultEscapedTable, testResult);
+    }
+}

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>tests</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\MarkdownUtilities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/xunit.runner.json
+++ b/tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
- Support for supplied `StringBuilder`
- `Build()` now works as part of the `StringBuilder` build chain instead of being `ToString()`
- "MD" removed from class names
  - `MDTableBuilder` -> `TableBuilder`
  - `MDTableColumn` -> `TableColumn`
- Added several extension methods for `StringBuilder` and `TableBuilder`
- Add tests
- Change solution and project config and update build script